### PR TITLE
Add OpenAI sentiment helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,11 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas openai
+   ```
+2. Create a `.env` file with your API keys:
+   ```bash
+   ALPACA_API_KEY=your_alpaca_key
+   ALPACA_SECRET_KEY=your_alpaca_secret
+   OPENAI_API_KEY=your_openai_key
+   ```


### PR DESCRIPTION
## Summary
- document openai in setup
- load OPENAI_API_KEY and add `summarize_sentiment`

## Testing
- `python -m py_compile bot.py`
- `python - <<'EOF'
import bot
try:
    print(bot.summarize_sentiment('Stocks rally on positive news'))
except Exception as e:
    print('Error:', e)
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_68466d861f908323967c9a72c8582110