### PR TITLE
Implement strategy comparison helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,11 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas yfinance
+```
+
+2. Compare strategies on historical data:
+   ```python
+   from bot import compare_strategies
+   compare_strategies("AAPL", [150, 170])
+   ```


### PR DESCRIPTION
## Summary
- backtest simple price threshold strategies with yfinance
- compare multiple strategies at once
- document the new helper in README

## Testing
- `python -m py_compile bot.py`
- `python - <<'PY'
import types, sys
sys.modules['alpaca_trade_api'] = types.SimpleNamespace(REST=None)
from bot import compare_strategies
results = compare_strategies("AAPL", [150, 170])
print(results)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68466c339df48323b3b16a7df0502f54