### PR TITLE
Implement news sentiment scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,10 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas textblob requests
+   ```
+2. (Optional) download TextBlob corpora:
+   ```bash
+   python -m textblob.download_corpora
+   ```
+3. Set your API keys in a `.env` file.


### PR DESCRIPTION
## Summary
- add TextBlob-based sentiment scoring for fetched news
- document new dependencies and setup steps

## Testing
- `pip install textblob requests`
- `python -m textblob.download_corpora -q`
- `python bot.py` *(fails: Missing Alpaca credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68466c867b148323918ee81893bd0698