### PR TITLE
Add historical trade simulation summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ This bot will:
 1. Install dependencies:
    ```bash
    pip install alpaca_trade_api python-dotenv pandas
+```
+
+2. Run a historical simulation with your CSV data:
+   ```bash
+   python -c "from bot import simulate_historical_trades; simulate_historical_trades('prices.csv')"
+   ```
+   This prints the total trades processed, how many buys were simulated,
+   win rate percentage, average entry price and the highest price reached
+   after each buy.

--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@ import csv
 from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
+import pandas as pd
 
 load_dotenv()
 
@@ -55,6 +56,52 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             "buy" if response else "skipped",
             strategy_used
         ])
+
+def simulate_historical_trades(csv_file: str, buy_threshold: float = 500.0) -> None:
+    """Simulate a simple buy strategy on historical data and print stats.
+
+    The CSV should contain at least a ``close`` column representing the
+    historical closing price of the asset. The function processes each row as
+    one candle in time. If the close price is below ``buy_threshold`` a buy is
+    simulated for the next candle.
+    """
+
+    df = pd.read_csv(csv_file)
+    if "close" not in df.columns:
+        raise ValueError("CSV must contain a 'close' column")
+
+    total_trades = len(df)
+    buy_prices = []
+    wins = 0
+    highest_after_buy = []
+
+    for i, price in enumerate(df["close"]):
+        if price < buy_threshold:
+            buy_prices.append(price)
+            # Determine if the immediate next candle closes higher
+            if i + 1 < len(df) and df["close"].iloc[i + 1] > price:
+                wins += 1
+
+            # Highest price seen after the buy point
+            if i + 1 < len(df):
+                highest_after_buy.append(df["close"].iloc[i + 1 :].max())
+            else:
+                highest_after_buy.append(price)
+
+    total_buys = len(buy_prices)
+    average_entry = sum(buy_prices) / total_buys if total_buys else 0
+    win_rate = (wins / total_buys) * 100 if total_buys else 0
+
+    print(f"Total trades processed: {total_trades}")
+    print(f"Total simulated buys: {total_buys}")
+    print(f"Win rate: {win_rate:.2f}%")
+    print(f"Average entry price: {average_entry:.2f}")
+
+    for idx, (entry, high) in enumerate(zip(buy_prices, highest_after_buy), 1):
+        potential_gain = ((high - entry) / entry) * 100 if entry else 0
+        print(
+            f"Buy {idx}: entry {entry:.2f}, highest after buy {high:.2f}, potential gain {potential_gain:.2f}%"
+        )
 
 if __name__ == "__main__":
     trade_and_log("AAPL", "price_under_500")


### PR DESCRIPTION
## Summary
- add pandas dependency and `simulate_historical_trades` helper in `bot.py`
- update README with instructions for running a historical simulation

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68466c2e3f8883238fb6876f4b72ddcd