### PR TITLE
Add strategy priority persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ This bot will:
 1. Install dependencies:
    ```bash
    pip install alpaca_trade_api python-dotenv pandas
+   ```
+
+2. (Optional) Create a strategy priority file which maps strategy names to
+   numeric priority scores:
+   ```python
+   from bot import save_strategy_priorities
+   save_strategy_priorities({"price_under_500": 1.0})
+   ```
+   The bot automatically loads this file on startup.


### PR DESCRIPTION
## Summary
- load/save strategy priorities in JSON
- print strategy priority at startup
- document strategy priority file in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68466bd0cce48323b1b57b75a5ddc36f