### PR TITLE
Add historical trade plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas matplotlib


### PR DESCRIPTION
## Summary
- add pandas & matplotlib usage
- implement `simulate_historical_trades` for plotting historical data with buy signals
- document matplotlib dependency in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68466c38889c83238368f03648a9e9f1