### PR TITLE
Add news headlines logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas requests
+   ```
+2. Set environment variables `ALPACA_API_KEY`, `ALPACA_SECRET_KEY` and `NEWS_API_KEY` with your credentials.


### PR DESCRIPTION
## Summary
- fetch latest top headlines using News API
- log the fetched news with each trade
- document required NEWS_API_KEY and requests dependency

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68466bde4f5c8323ae92022474b78919