### PR TITLE
Add strategy chooser function

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@
 import os
 import csv
 from datetime import datetime
+
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
 
@@ -11,6 +12,46 @@ load_dotenv()
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+
+
+def choose_strategy(performance_file: str = "strategy_performance.csv",
+                    default: str = "test_strategy") -> str:
+    """Select the strategy with the highest win rate.
+
+    The performance file should contain rows with ``strategy``, ``wins`` and
+    ``losses`` columns. If the file does not exist or there is no valid data,
+    the provided ``default`` strategy is returned.
+    """
+
+    if not os.path.exists(performance_file):
+        print(f"Performance file {performance_file} not found. Using default strategy.")
+        return default
+
+    best_strategy = default
+    best_rate = -1.0
+
+    with open(performance_file, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                wins = int(row.get("wins", 0))
+                losses = int(row.get("losses", 0))
+            except ValueError:
+                continue
+            total = wins + losses
+            if total == 0:
+                continue
+            rate = wins / total
+            if rate > best_rate:
+                best_rate = rate
+                best_strategy = row.get("strategy", default)
+
+    if best_rate >= 0:
+        print(f"Chosen strategy: {best_strategy} (win rate {best_rate:.2%})")
+    else:
+        print("No valid performance data found. Using default strategy.")
+
+    return best_strategy
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
@@ -57,4 +98,5 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
         ])
 
 if __name__ == "__main__":
-    trade_and_log("AAPL", "price_under_500")
+    strategy = choose_strategy()
+    trade_and_log("AAPL", strategy)


### PR DESCRIPTION
## Summary
- implement `choose_strategy` to pick highest win rate strategy
- update main to use this strategy selector

## Testing
- `python3 -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68466bca957483239e7f900c07b4d781