### PR TITLE
Implement evolve_strategy function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ This bot will:
 1. Install dependencies:
    ```bash
    pip install alpaca_trade_api python-dotenv pandas
+   ```
+
+2. Evolve strategies based on the trade log:
+   ```bash
+   python -c "import bot; bot.evolve_strategy()"
+   ```


### PR DESCRIPTION
## Summary
- add evolve_strategy to adjust strategy priority based on trade log
- document how to run evolve_strategy in README

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466ad0b1a083238f45a58451a5c255