### PR TITLE
Add historical spike detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ This bot will:
 1. Install dependencies:
    ```bash
    pip install alpaca_trade_api python-dotenv pandas
+   ```
+
+### Simulate Historical Trades
+
+After you have a `trade_log.csv` file, analyze skipped trades with:
+
+```bash
+python bot.py simulate
+```


### PR DESCRIPTION
## Summary
- highlight skipped trades that spiked later
- mention simulation option in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684671024fd0832380fa858d9317cbc7