### PR TITLE
Add brain confidence adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This bot will:
 - Trade any stock
 - Log detailed trade data to CSV
 - Begin self-analysis loop on trade outcomes
+- Adjust strategy confidence with `Brain.compare_advice_with_trade`
 
 ## 🛠 Setup
 

--- a/bot.py
+++ b/bot.py
@@ -6,11 +6,15 @@ from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
 
+from brain import Brain
+
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+
+brain = Brain()
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
@@ -44,6 +48,16 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             print(f"Order failed: {e}")
     else:
         print("Price too high. No order placed.")
+
+    profit = 0.0
+    if response:
+        try:
+            latest_after = api.get_latest_trade(symbol)
+            after_price = float(latest_after.price)
+            profit = after_price - price
+        except Exception as e:
+            print(f"Failed to fetch post-trade price for {symbol}: {e}")
+    brain.compare_advice_with_trade(strategy_used, "buy", profit)
 
     # Log everything for future learning
     with open("trade_log.csv", "a", newline="") as f:

--- a/brain.py
+++ b/brain.py
@@ -1,0 +1,33 @@
+class Brain:
+    """Simple structure to store advice history and update confidence/priority."""
+
+    def __init__(self):
+        self.history = {}
+
+    def compare_advice_with_trade(self, advice_id, advice_action, profit):
+        """Adjust confidence and priority based on trade outcome.
+
+        Parameters
+        ----------
+        advice_id : hashable
+            Identifier for the advice or rule.
+        advice_action : str
+            Either ``"buy"`` or ``"sell"``.
+        profit : float
+            The profit (positive or negative) from acting on the advice.
+        """
+        record = self.history.get(advice_id, {"confidence": 1.0, "priority": 1})
+
+        was_correct = (profit > 0 and advice_action == "buy") or (
+            profit < 0 and advice_action == "sell"
+        )
+
+        if was_correct:
+            record["confidence"] += 0.1
+            record["priority"] += 1
+        else:
+            record["confidence"] = max(0.0, record["confidence"] - 0.1)
+            record["priority"] = max(1, record["priority"] - 1)
+
+        self.history[advice_id] = record
+        return record


### PR DESCRIPTION
## Summary
- document self-improvement step in README
- add a `Brain` class to maintain advice confidence
- update bot example to use the new brain

## Testing
- `python -m py_compile bot.py brain.py`

------
https://chatgpt.com/codex/tasks/task_e_6846730a93208323a569abe1b5301562