### PR TITLE
Add persistent analyst memory log

### DIFF
--- a/analyst_memory.txt
+++ b/analyst_memory.txt
@@ -1,0 +1,1 @@
+timestamp,brain,advice,reasoning

--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,19 @@ from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
 
+MEMORY_FILE = "analyst_memory.txt"
+
+def log_brain_memory(brain: str, advice: str, reasoning: str, memory_file: str = MEMORY_FILE) -> None:
+    """Append a line of advice and reasoning for a brain to the memory file."""
+    with open(memory_file, "a", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            datetime.utcnow().isoformat(),
+            brain,
+            advice,
+            reasoning,
+        ])
+
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
@@ -40,10 +53,13 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
                 time_in_force="gtc",
             )
             print("Buy order placed.")
+            log_brain_memory("trade_brain", "buy", "price under 500")
         except Exception as e:
             print(f"Order failed: {e}")
+            log_brain_memory("trade_brain", "failed_order", str(e))
     else:
         print("Price too high. No order placed.")
+        log_brain_memory("trade_brain", "skip", "price too high")
 
     # Log everything for future learning
     with open("trade_log.csv", "a", newline="") as f:


### PR DESCRIPTION
## Summary
- add a CSV memory file for logging analyst outputs
- implement `log_brain_memory` to append advice and reasoning
- log trading decisions into the analyst memory

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684673102d7c8323a538d2a8c892298e