### PR TITLE
Add strategy mutation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This bot will:
 - Trade any stock
 - Log detailed trade data to CSV
 - Begin self-analysis loop on trade outcomes
+- Mutate strategies to test new price thresholds
 
 ## 🛠 Setup
 


### PR DESCRIPTION
## Summary
- build a simple strategy class and mutation helper
- update trading bot to use strategy objects
- document strategy mutation in README

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467351a80c8323993168ee89682b8f