### PR TITLE
Add market calendar checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas pandas_market_calendars

--- a/bot.py
+++ b/bot.py
@@ -2,9 +2,10 @@
 
 import os
 import csv
-from datetime import datetime
+from datetime import datetime, timezone
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
+import pandas_market_calendars as mcal
 
 load_dotenv()
 
@@ -12,8 +13,38 @@ API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
 
+# Predefined dates of upcoming FOMC announcements (YYYY-MM-DD). In practice
+# this should be fetched from an external calendar.
+FOMC_DATES = {
+    "2024-06-12",
+    "2024-07-31",
+    "2024-09-18",
+    "2024-11-07",
+    "2024-12-18",
+}
+
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
+    today = datetime.now(timezone.utc).date()
+    nyse = mcal.get_calendar("NYSE")
+    # Skip trading on weekends and market holidays
+    sched = nyse.schedule(start_date=today, end_date=today)
+    if sched.empty:
+        print("Market closed today. Skipping trading.")
+        return
+
+    close_time = sched.iloc[0]["market_close"].tz_convert("America/New_York")
+    low_volume = False
+    notes = []
+    if close_time.hour < 16:
+        low_volume = True
+        notes.append("half-day")
+        print("Early close detected. Low volume expected.")
+
+    if today.isoformat() in FOMC_DATES:
+        low_volume = True
+        notes.append("FOMC")
+        print("FOMC announcement today. Volume may be lower.")
     if not API_KEY or not SECRET_KEY:
         print("Missing Alpaca credentials.")
         return
@@ -49,11 +80,13 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     with open("trade_log.csv", "a", newline="") as f:
         writer = csv.writer(f)
         writer.writerow([
-            datetime.utcnow().isoformat(),
+            datetime.now(timezone.utc).isoformat(),
             symbol,
             price,
             "buy" if response else "skipped",
-            strategy_used
+            strategy_used,
+            "low_volume" if low_volume else "normal_volume",
+            "|".join(notes)
         ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- install `pandas_market_calendars`
- check NYSE calendar before trading
- flag early closes and FOMC dates as low-volume
- log volume status in `trade_log.csv`

## Testing
- `python bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6846736387208323ae7bb458e29ceb19