### PR TITLE
Implement VIX safety check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,12 +5,26 @@ import csv
 from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
+import yfinance as yf
 
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+DANGER_VIX_THRESHOLD = float(os.getenv("DANGER_VIX_THRESHOLD", "30"))
+
+
+def get_vix_value() -> float | None:
+    """Fetch the latest VIX value using yfinance."""
+    try:
+        vix = yf.Ticker("^VIX")
+        data = vix.history(period="1d")
+        if not data.empty:
+            return float(data["Close"].iloc[-1])
+    except Exception as exc:
+        print(f"Failed to fetch VIX data: {exc}")
+    return None
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
@@ -20,6 +34,24 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
 
     api = tradeapi.REST(API_KEY, SECRET_KEY, base_url=BASE_URL)
     print(f"Watching {symbol.upper()}...")
+
+    vix = get_vix_value()
+    if vix is not None and vix > DANGER_VIX_THRESHOLD:
+        print(
+            f"High volatility detected: VIX {vix} > {DANGER_VIX_THRESHOLD}. Halting trade."
+        )
+        with open("trade_log.csv", "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([
+                datetime.utcnow().isoformat(),
+                symbol,
+                "N/A",
+                "skipped",
+                strategy_used,
+                vix,
+                "vix_above_threshold",
+            ])
+        return
 
     try:
         latest_trade = api.get_latest_trade(symbol)
@@ -53,7 +85,9 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             symbol,
             price,
             "buy" if response else "skipped",
-            strategy_used
+            strategy_used,
+            vix,
+            ""
         ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add helper to fetch latest VIX with yfinance
- halt trading when volatility exceeds `DANGER_VIX_THRESHOLD`
- log the halt reason and VIX value in `trade_log.csv`

## Testing
- `python bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68467376f0f48323b486f0378d727a47