### PR TITLE
Add backtest loop for strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ This bot will:
 1. Install dependencies:
    ```bash
    pip install alpaca_trade_api python-dotenv pandas
+   ```
+
+2. Run the example backtests (optional):
+   ```bash
+   python backtest.py
+   ```

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,44 @@
+import json
+import os
+import random
+
+
+def example_strategy(_):
+    """Placeholder strategy that randomly wins or loses."""
+    return random.choice([True, False])
+
+
+def run_backtest(strategy_func, trials=100):
+    """Run a simple backtest returning win rate."""
+    wins = sum(strategy_func(None) for _ in range(trials))
+    return wins / trials
+
+
+def main():
+    strategies = {
+        "ma_crossover": example_strategy,
+        "rsi_reversal": example_strategy,
+        "buy_and_hold": example_strategy,
+    }
+
+    scores = {}
+    if os.path.exists("strategy_scores.json"):
+        with open("strategy_scores.json", "r") as f:
+            try:
+                scores = json.load(f)
+            except json.JSONDecodeError:
+                scores = {}
+
+    for name, func in strategies.items():
+        win_rate = run_backtest(func)
+        print(f"{name} win rate: {win_rate:.2%}")
+        scores[name] = win_rate
+
+    with open("strategy_scores.json", "w") as f:
+        json.dump(scores, f, indent=2)
+        f.write("\n")
+    print("Updated strategy_scores.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/strategy_scores.json
+++ b/strategy_scores.json
@@ -1,0 +1,5 @@
+{
+  "ma_crossover": 0.52,
+  "rsi_reversal": 0.46,
+  "buy_and_hold": 0.57
+}


### PR DESCRIPTION
## Summary
- add `backtest.py` that loops through several example strategies
- write each strategy's win rate to `strategy_scores.json`
- update README with instructions for running the backtest

## Testing
- `python -m py_compile bot.py backtest.py`
- `python backtest.py`


------
https://chatgpt.com/codex/tasks/task_e_6846738761e48323b2c645238311c2b8