### PR TITLE
Implement trade cooldown tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+trade_log.csv
+last_trades.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This bot will:
 - Connect to Alpaca Paper API
 - Trade any stock
 - Log detailed trade data to CSV
+- Track recent trade timestamps to avoid over-trading a symbol
 - Begin self-analysis loop on trade outcomes
 
 ## 🛠 Setup

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@
 
 import os
 import csv
+import json
 from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
@@ -12,14 +13,45 @@ API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
 
-def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
-    """Trade any stock and log the decision, price, time, and logic used."""
+# Track last trade time and price per symbol
+LAST_TRADES_FILE = "last_trades.json"
+LAST_TRADES = {}
+
+if os.path.exists(LAST_TRADES_FILE):
+    try:
+        with open(LAST_TRADES_FILE, "r") as f:
+            LAST_TRADES = json.load(f)
+    except Exception:
+        LAST_TRADES = {}
+
+def _save_last_trades() -> None:
+    """Persist last trade timestamps and prices to file."""
+    try:
+        with open(LAST_TRADES_FILE, "w") as f:
+            json.dump(LAST_TRADES, f)
+    except Exception as e:
+        print(f"Failed to save last trades: {e}")
+
+def trade_and_log(symbol: str, strategy_used: str = "test_strategy", news_update: bool = False) -> None:
+    """Trade any stock and log the decision, price, time, and logic used.
+
+    Parameters
+    ----------
+    symbol : str
+        Ticker symbol to trade.
+    strategy_used : str, optional
+        Description of strategy for logging purposes.
+    news_update : bool, optional
+        If True, indicates new sentiment data is available allowing trades even
+        within the cooldown window.
+    """
     if not API_KEY or not SECRET_KEY:
         print("Missing Alpaca credentials.")
         return
 
+    symbol = symbol.upper()
     api = tradeapi.REST(API_KEY, SECRET_KEY, base_url=BASE_URL)
-    print(f"Watching {symbol.upper()}...")
+    print(f"Watching {symbol}...")
 
     try:
         latest_trade = api.get_latest_trade(symbol)
@@ -29,8 +61,25 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
         print(f"Failed to fetch price for {symbol}: {e}")
         return
 
+    # Determine if a recent trade was placed
+    skip_trade = False
+    last_info = LAST_TRADES.get(symbol)
+    if last_info:
+        try:
+            last_time = datetime.fromisoformat(last_info.get("time"))
+            minutes_since = (datetime.utcnow() - last_time).total_seconds() / 60
+            last_price = float(last_info.get("price", price))
+            drop_pct = (last_price - price) / last_price
+            if minutes_since < 15 and not (drop_pct > 0.02 or news_update):
+                print(
+                    f"Traded {symbol} {minutes_since:.1f} min ago and price hasn't dropped >2%. Skipping buy."
+                )
+                skip_trade = True
+        except Exception:
+            pass
+
     response = None
-    if price < 500:  # Placeholder logic
+    if not skip_trade and price < 500:  # Placeholder logic
         try:
             response = api.submit_order(
                 symbol=symbol,
@@ -40,8 +89,15 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
                 time_in_force="gtc",
             )
             print("Buy order placed.")
+            LAST_TRADES[symbol] = {
+                "time": datetime.utcnow().isoformat(),
+                "price": price,
+            }
+            _save_last_trades()
         except Exception as e:
             print(f"Order failed: {e}")
+    elif skip_trade:
+        print("Trade skipped due to recent activity.")
     else:
         print("Price too high. No order placed.")
 
@@ -53,7 +109,8 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             symbol,
             price,
             "buy" if response else "skipped",
-            strategy_used
+            strategy_used,
+            bool(news_update)
         ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track last trade per symbol in `last_trades.json`
- skip buys if traded within 15 minutes unless price dropped >2% or news sentiment updates
- log whether a news update triggered the trade
- document trade timestamp tracking in README
- ignore generated files

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6846747483688323b50392c2416476af