### PR TITLE
Implement bankroll management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ This bot will:
 1. Install dependencies:
    ```bash
    pip install alpaca_trade_api python-dotenv pandas
+   ```
+
+2. The bot tracks its cash in `account_balance.json`. The file is created
+   automatically with a `$700` starting balance. Cash from sales is held in
+   a pending settlement account until the next trading day.

--- a/account.py
+++ b/account.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+from datetime import datetime, timedelta
+
+ACCOUNT_FILE = "account_balance.json"
+
+
+def load_account():
+    """Load account data from disk or initialize it the first time."""
+    if Path(ACCOUNT_FILE).exists():
+        with open(ACCOUNT_FILE, "r") as f:
+            data = json.load(f)
+    else:
+        data = {
+            "cash": 700.0,
+            "pending_settlements": [],
+            "positions": {},
+        }
+        save_account(data)
+    return data
+
+
+def save_account(data):
+    with open(ACCOUNT_FILE, "w") as f:
+        json.dump(data, f, indent=4)
+
+
+def process_settlements(data):
+    """Release pending settlements if their release date has passed."""
+    today = datetime.utcnow().date()
+    remaining = []
+    for p in data.get("pending_settlements", []):
+        release = datetime.fromisoformat(p["release_date"]).date()
+        if release <= today:
+            data["cash"] += p["amount"]
+        else:
+            remaining.append(p)
+    data["pending_settlements"] = remaining
+    return data
+
+
+def deduct_cash(data, amount):
+    if data.get("cash", 0) >= amount:
+        data["cash"] -= amount
+        return True
+    return False
+
+
+def add_pending_settlement(data, amount):
+    release_date = (datetime.utcnow() + timedelta(days=1)).date().isoformat()
+    data.setdefault("pending_settlements", []).append({
+        "amount": amount,
+        "release_date": release_date,
+    })
+    return data
+
+
+def add_position(data, symbol, qty):
+    positions = data.setdefault("positions", {})
+    positions[symbol] = positions.get(symbol, 0) + qty
+    return data
+
+
+def remove_position(data, symbol, qty):
+    positions = data.setdefault("positions", {})
+    current = positions.get(symbol, 0)
+    if qty >= current:
+        positions.pop(symbol, None)
+    else:
+        positions[symbol] = current - qty
+    return data

--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,16 @@ from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
 
+from account import (
+    load_account,
+    save_account,
+    process_settlements,
+    deduct_cash,
+    add_pending_settlement,
+    add_position,
+    remove_position,
+)
+
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
@@ -16,6 +26,12 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
     if not API_KEY or not SECRET_KEY:
         print("Missing Alpaca credentials.")
+        return
+
+    account = process_settlements(load_account())
+    if account.get("cash", 0) < 1:
+        print("Insufficient cash to trade today.")
+        save_account(account)
         return
 
     api = tradeapi.REST(API_KEY, SECRET_KEY, base_url=BASE_URL)
@@ -30,20 +46,45 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
         return
 
     response = None
-    if price < 500:  # Placeholder logic
+    side = "skipped"
+    trade_cost = price * 1  # buying one share
+    if price < 500:  # Placeholder buy logic
+        if deduct_cash(account, trade_cost):
+            try:
+                response = api.submit_order(
+                    symbol=symbol,
+                    qty=1,
+                    side="buy",
+                    type="market",
+                    time_in_force="gtc",
+                )
+                add_position(account, symbol, 1)
+                side = "buy"
+                print("Buy order placed.")
+            except Exception as e:
+                print(f"Order failed: {e}")
+                account["cash"] += trade_cost
+        else:
+            print("Not enough settled cash for trade.")
+    elif price > 520 and account.get("positions", {}).get(symbol, 0) > 0:
         try:
             response = api.submit_order(
                 symbol=symbol,
                 qty=1,
-                side="buy",
+                side="sell",
                 type="market",
                 time_in_force="gtc",
             )
-            print("Buy order placed.")
+            remove_position(account, symbol, 1)
+            add_pending_settlement(account, price)
+            side = "sell"
+            print("Sell order placed.")
         except Exception as e:
             print(f"Order failed: {e}")
     else:
-        print("Price too high. No order placed.")
+        print("No trading action taken.")
+
+    save_account(account)
 
     # Log everything for future learning
     with open("trade_log.csv", "a", newline="") as f:
@@ -52,8 +93,8 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             datetime.utcnow().isoformat(),
             symbol,
             price,
-            "buy" if response else "skipped",
-            strategy_used
+            side if response else "skipped",
+            strategy_used,
         ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track account balances in `account_balance.json`
- update funds on buys, sales, and daily settlement
- stop trading if cash is too low
- document bankroll file in README
- start new accounts with a $700 balance

## Testing
- `python -m py_compile bot.py account.py`


------
https://chatgpt.com/codex/tasks/task_e_6846767333b08323ba1c8727b1cd7ec9