### PR TITLE
Add news sentiment filter using NewsAPI and GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ This bot will:
 - Trade any stock
 - Log detailed trade data to CSV
 - Begin self-analysis loop on trade outcomes
+- Check recent news with `news_risk_filter()` for GPT-powered risk scoring
 
 ## 🛠 Setup
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas requests openai
+   ```
+
+2. Set environment variables for your API keys:
+   - `ALPACA_API_KEY` and `ALPACA_SECRET_KEY`
+   - `NEWS_API_KEY` for [NewsAPI](https://newsapi.org)
+   - `OPENAI_API_KEY` for OpenAI

--- a/bot.py
+++ b/bot.py
@@ -3,14 +3,70 @@
 import os
 import csv
 from datetime import datetime
+from typing import Optional, List
+
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
+import requests
+import openai
 
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+NEWS_API_KEY = os.getenv("NEWS_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+def news_risk_filter(symbol: str) -> Optional[str]:
+    """Return GPT classification of recent news for the symbol."""
+    if not NEWS_API_KEY or not OPENAI_API_KEY:
+        print("Missing NewsAPI or OpenAI credentials.")
+        return None
+
+    url = (
+        "https://newsapi.org/v2/everything"
+        f"?q={symbol}&sortBy=publishedAt&language=en&apiKey={NEWS_API_KEY}"
+    )
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        print(f"NewsAPI request failed: {exc}")
+        return None
+
+    headlines: List[str] = [a.get("title", "") for a in data.get("articles", [])][:5]
+    if not headlines:
+        print("No headlines found.")
+        classification = "neutral"
+    else:
+        openai.api_key = OPENAI_API_KEY
+        prompt = (
+            "Classify the following stock news headlines as 'risky', 'neutral', or 'positive'.\n"
+            + "\n".join(f"- {h}" for h in headlines)
+        )
+        try:
+            chat = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=5,
+            )
+            classification = chat["choices"][0]["message"]["content"].strip().lower()
+        except Exception as exc:
+            print(f"OpenAI request failed: {exc}")
+            classification = "neutral"
+
+    with open("news_log.csv", "a", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            datetime.utcnow().isoformat(),
+            symbol,
+            " ; ".join(headlines),
+            classification,
+        ])
+
+    return classification
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""


### PR DESCRIPTION
## Summary
- support requests and openai dependencies
- store API keys for NewsAPI and OpenAI
- implement `news_risk_filter` to classify news as risky/neutral/positive
- log news headlines and classification to `news_log.csv`
- document new setup and feature in README

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467a48ca0c8323bd25c526943092f4