### PR TITLE
Add trade retry mechanism

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,12 +5,44 @@ import csv
 from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
+import requests
+import time
 
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+
+
+def submit_order_with_retry(api: tradeapi.REST, max_attempts: int = 3, **order_kwargs):
+    """Submit an order and retry on network or API errors up to max_attempts."""
+    attempts = 0
+    last_error = ""
+    while attempts < max_attempts:
+        try:
+            response = api.submit_order(**order_kwargs)
+            print("Buy order placed.")
+            return response, attempts + 1, ""
+        except tradeapi.rest.APIError as e:
+            message = str(e)
+            # Do not retry logical errors
+            if "insufficient" in message.lower() or "buying power" in message.lower():
+                print(f"Order failed: {message}")
+                return None, attempts + 1, message
+            attempts += 1
+            last_error = message
+            print(f"API error on attempt {attempts}: {message}")
+        except requests.exceptions.RequestException as e:
+            attempts += 1
+            last_error = str(e)
+            print(f"Network error on attempt {attempts}: {e}")
+
+        if attempts < max_attempts:
+            time.sleep(1)
+
+    print(f"All {attempts} attempts failed. Error: {last_error}")
+    return None, attempts, last_error
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
@@ -30,18 +62,17 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
         return
 
     response = None
+    attempts = 0
+    error_message = ""
     if price < 500:  # Placeholder logic
-        try:
-            response = api.submit_order(
-                symbol=symbol,
-                qty=1,
-                side="buy",
-                type="market",
-                time_in_force="gtc",
-            )
-            print("Buy order placed.")
-        except Exception as e:
-            print(f"Order failed: {e}")
+        response, attempts, error_message = submit_order_with_retry(
+            api,
+            symbol=symbol,
+            qty=1,
+            side="buy",
+            type="market",
+            time_in_force="gtc",
+        )
     else:
         print("Price too high. No order placed.")
 
@@ -53,7 +84,9 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             symbol,
             price,
             "buy" if response else "skipped",
-            strategy_used
+            strategy_used,
+            attempts,
+            error_message
         ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add function `submit_order_with_retry` that retries network or API failures
- log attempts and final errors when submitting orders
- log attempts and error details in CSV

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467e3aa8dc8323b24e09905ed12c61