### PR TITLE
Add Telegram alerts to trading bot

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -1,0 +1,22 @@
+import os
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+
+
+def send_telegram_alert(message: str) -> None:
+    """Send a message to the configured Telegram chat."""
+    if not BOT_TOKEN or not CHAT_ID:
+        print("Missing Telegram credentials.")
+        return
+
+    url = f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage"
+    data = {"chat_id": CHAT_ID, "text": message}
+    try:
+        requests.post(url, data=data, timeout=10)
+    except Exception as e:
+        print(f"Failed to send Telegram alert: {e}")


### PR DESCRIPTION
## Summary
- notify Telegram using a helper `send_telegram_alert`
- add alert calls for trade decisions
- alert when switching between live and paper mode if losses exceed a threshold

## Testing
- `python -m py_compile bot.py alerts.py`

------
https://chatgpt.com/codex/tasks/task_e_684680d754588323a888964d0f6138bf