### PR TITLE
Add daily Telegram summary function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This bot will:
 - Trade any stock
 - Log detailed trade data to CSV
 - Begin self-analysis loop on trade outcomes
+- Send a daily Telegram summary of trades
 
 ## 🛠 Setup
 

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,9 @@
 
 import os
 import csv
-from datetime import datetime
+from datetime import datetime, date, time, timedelta
+from zoneinfo import ZoneInfo
+import requests
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
 
@@ -11,6 +13,22 @@ load_dotenv()
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+EASTERN = ZoneInfo("US/Eastern")
+
+
+def send_telegram_message(message: str) -> None:
+    """Send a text message to the configured Telegram chat."""
+    if not TELEGRAM_TOKEN or not TELEGRAM_CHAT_ID:
+        print("Missing Telegram credentials.")
+        return
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+    payload = {"chat_id": TELEGRAM_CHAT_ID, "text": message}
+    try:
+        requests.post(url, data=payload, timeout=10)
+    except Exception as exc:
+        print(f"Failed to send Telegram message: {exc}")
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
@@ -56,5 +74,66 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             strategy_used
         ])
 
+
+def send_daily_summary() -> None:
+    """Compile today's trade data and send a brief summary to Telegram."""
+    today = datetime.now(EASTERN).date()
+    buys = sells = skips = 0
+    net = 0.0
+    open_positions: dict[str, list[float]] = {}
+    profits: list[float] = []
+
+    if not os.path.exists("trade_log.csv"):
+        print("No trade log found to summarize.")
+        return
+
+    with open("trade_log.csv", newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) < 4:
+                continue
+            timestamp, symbol, price, action = row[:4]
+            try:
+                entry_date = datetime.fromisoformat(timestamp).date()
+            except ValueError:
+                continue
+            if entry_date != today:
+                continue
+            price = float(price)
+
+            if action == "buy":
+                buys += 1
+                open_positions.setdefault(symbol, []).append(price)
+            elif action == "sell":
+                sells += 1
+                if open_positions.get(symbol):
+                    buy_price = open_positions[symbol].pop(0)
+                    profit = price - buy_price
+                    profits.append(profit)
+                    net += profit
+                else:
+                    net += price
+            else:
+                skips += 1
+
+    win_rate_msg = "N/A"
+    if profits:
+        wins = sum(1 for p in profits if p > 0)
+        win_rate_msg = f"{wins / len(profits) * 100:.2f}%"
+
+    summary = (
+        f"Daily Summary ({today}):\n"
+        f"Buys: {buys}\n"
+        f"Sells: {sells}\n"
+        f"Skips: {skips}\n"
+        f"Win Rate: {win_rate_msg}\n"
+        f"Net P/L: {net:.2f}"
+    )
+
+    send_telegram_message(summary)
+
 if __name__ == "__main__":
     trade_and_log("AAPL", "price_under_500")
+    now_est = datetime.now(EASTERN)
+    if now_est.time() >= time(16, 0):
+        send_daily_summary()


### PR DESCRIPTION
## Summary
- send Telegram messages via new helper
- compile daily trade summary and send at market close
- trigger summary in main when run after 4PM EST
- document feature in README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684681ec4e1483239c4aaa7cf96119c1