### PR TITLE
Enhance trade logging with news links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,10 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas requests
+   ```
+
+2. Set up environment variables in a `.env` file:
+   - `ALPACA_API_KEY` and `ALPACA_SECRET_KEY`
+   - `NEWS_API_KEY` for fetching daily headlines
+


### PR DESCRIPTION
## Summary
- fetch daily news headlines with `fetch_headlines`
- call `news_brain` and `risk_brain` after losses
- log exit price and related headlines
- document new `requests` dependency and environment variable setup

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6846fea04bfc83238ccdcf03a73b4515