### PR TITLE
Add trade strategy labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This bot will:
 - Trade any stock
 - Log detailed trade data to CSV
 - Begin self-analysis loop on trade outcomes
+- Label each trade with its strategy (e.g. `breakout`, `pullback`) for easier analysis
 
 ## 🛠 Setup
 

--- a/bot.py
+++ b/bot.py
@@ -12,8 +12,8 @@ API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
 
-def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
-    """Trade any stock and log the decision, price, time, and logic used."""
+def trade_and_log(symbol: str, strategy_used: str = "test_strategy", label: str = "general"):
+    """Trade any stock and log the decision, price, time, strategy, and label."""
     if not API_KEY or not SECRET_KEY:
         print("Missing Alpaca credentials.")
         return
@@ -53,8 +53,9 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             symbol,
             price,
             "buy" if response else "skipped",
-            strategy_used
+            strategy_used,
+            label
         ])
 
 if __name__ == "__main__":
-    trade_and_log("AAPL", "price_under_500")
+    trade_and_log("AAPL", "price_under_500", "breakout")


### PR DESCRIPTION
## Summary
- allow labeling each trade via `label` argument
- capture strategy label in `trade_log.csv`
- document labeling requirement in README

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(fails without creds but prints message)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd3cbc648323b2a59e355e4eb569