### PR TITLE
Implement risk-based position sizing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,8 @@
 
 import os
 import csv
+import math
+from typing import Optional
 from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
@@ -12,8 +14,27 @@ API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
 
-def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
-    """Trade any stock and log the decision, price, time, and logic used."""
+
+def calculate_position_size(max_risk_per_trade: float, entry_price: float, stop_loss_price: float) -> int:
+    """Return share size based on risk tolerance.
+
+    position_size = max_risk_per_trade / (entry_price - stop_loss_price)
+    Result is floored to the nearest whole share.
+    """
+    risk_per_share = entry_price - stop_loss_price
+    if risk_per_share <= 0:
+        raise ValueError("Entry price must be greater than stop loss price.")
+
+    size = max_risk_per_trade / risk_per_share
+    return math.floor(size)
+
+def trade_and_log(
+    symbol: str,
+    strategy_used: str = "test_strategy",
+    max_risk_per_trade: float = 0.0,
+    stop_loss_price: Optional[float] = None,
+) -> None:
+    """Trade any stock based on risk and log the decision."""
     if not API_KEY or not SECRET_KEY:
         print("Missing Alpaca credentials.")
         return
@@ -29,21 +50,35 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
         print(f"Failed to fetch price for {symbol}: {e}")
         return
 
-    response = None
-    if price < 500:  # Placeholder logic
+    if stop_loss_price is None:
+        print("Stop loss price required for position sizing.")
+        return
+
+    try:
+        position_size = calculate_position_size(max_risk_per_trade, price, stop_loss_price)
+    except ValueError as e:
+        print(f"Invalid risk parameters: {e}")
+        return
+
+    if position_size < 1:
+        print("Position size below 1 share based on risk. No order placed.")
+        position_size = 0
+        response = None
+    elif price < 500:  # Placeholder logic
         try:
             response = api.submit_order(
                 symbol=symbol,
-                qty=1,
+                qty=position_size,
                 side="buy",
                 type="market",
                 time_in_force="gtc",
             )
-            print("Buy order placed.")
+            print(f"Buy order placed for {position_size} shares.")
         except Exception as e:
             print(f"Order failed: {e}")
     else:
         print("Price too high. No order placed.")
+        response = None
 
     # Log everything for future learning
     with open("trade_log.csv", "a", newline="") as f:
@@ -53,8 +88,10 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             symbol,
             price,
             "buy" if response else "skipped",
-            strategy_used
+            strategy_used,
+            position_size,
         ])
 
 if __name__ == "__main__":
-    trade_and_log("AAPL", "price_under_500")
+    # Example usage with $100 risk and a $5 stop loss distance
+    trade_and_log("AAPL", "price_under_500", max_risk_per_trade=100, stop_loss_price=495)


### PR DESCRIPTION
## Summary
- add `calculate_position_size` helper
- require stop loss and max risk in `trade_and_log`
- use calculated size when submitting orders
- log the position size

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6848bd67c8ac8323a2fff0f911a6f7e9