### PR TITLE
Add ATR-based risk management

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This bot will:
 - Connect to Alpaca Paper API
 - Trade any stock
 - Log detailed trade data to CSV
+- Define stop loss and take profit with ATR so no trade has open-ended risk
 - Begin self-analysis loop on trade outcomes
 
 ## 🛠 Setup


### PR DESCRIPTION
## Summary
- calculate a simple ATR from daily bars
- place bracket orders with stop loss and take profit based on ATR
- log stop and target levels
- document ATR stop-loss and take-profit in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bd0b09ac8323b521aa88ad632997