### PR TITLE
Add Telegram bot with OpenAI replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,15 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+    pip install alpaca_trade_api python-dotenv pandas \
+        python-telegram-bot==13.7 openai
+   ```
+2. Set environment variables `TELEGRAM_BOT_TOKEN` and `OPENAI_API_KEY`.
+
+## 📱 Telegram Bot
+
+Run `python telegram_bot.py` to start a Telegram bot that:
+
+- Replies to `/lasttrade` with the last entry in `trade_log.csv`.
+- Replies to `/summary` using `send_daily_summary()`.
+- Sends any other message to OpenAI and returns the response.

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,76 @@
+import os
+import csv
+from dotenv import load_dotenv
+from telegram import Update
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackContext
+from openai import OpenAI
+
+load_dotenv()
+
+
+def send_daily_summary() -> str:
+    """Placeholder daily summary function."""
+    return "Daily summary placeholder."
+
+
+def _read_last_trade() -> str:
+    try:
+        with open("trade_log.csv", newline="") as f:
+            rows = list(csv.reader(f))
+            if not rows:
+                return "Trade log is empty."
+            last = rows[-1]
+            return (
+                f"Time: {last[0]}\n"
+                f"Symbol: {last[1]}\n"
+                f"Price: {last[2]}\n"
+                f"Action: {last[3]}\n"
+                f"Strategy: {last[4]}"
+            )
+    except FileNotFoundError:
+        return "trade_log.csv not found."
+
+
+def last_trade(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(_read_last_trade())
+
+
+def summary(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(send_daily_summary())
+
+
+def chat_with_gpt(prompt: str) -> str:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return "OpenAI API key is not configured."
+    client = OpenAI(api_key=api_key)
+    try:
+        resp = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception as e:  # pragma: no cover - network call
+        return f"Error contacting OpenAI: {e}"
+
+
+def answer(update: Update, context: CallbackContext) -> None:
+    update.message.reply_text(chat_with_gpt(update.message.text))
+
+
+def main() -> None:
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        print("TELEGRAM_BOT_TOKEN not set.")
+        return
+    updater = Updater(token, use_context=True)
+    dp = updater.dispatcher
+    dp.add_handler(CommandHandler("lasttrade", last_trade))
+    dp.add_handler(CommandHandler("summary", summary))
+    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, answer))
+    updater.start_polling()
+    updater.idle()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Telegram bot that can return the last trade and chat with GPT
- document how to install dependencies and run the Telegram bot

## Testing
- `python -m py_compile telegram_bot.py`
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6849075b23ec83238158219269bb40c2