### PR TITLE
Implement Telegram trade alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,10 @@ This bot will:
 ## 🛠 Setup
 
 1. Install dependencies:
-   ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+    ```bash
+    pip install alpaca_trade_api python-dotenv pandas requests
+    ```
+
+2. Set environment variables (e.g. using a `.env` file):
+    - `ALPACA_API_KEY` and `ALPACA_SECRET_KEY`
+    - `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` for Telegram alerts

--- a/bot.py
+++ b/bot.py
@@ -5,12 +5,25 @@ import csv
 from datetime import datetime
 from dotenv import load_dotenv
 import alpaca_trade_api as tradeapi
+import requests
 
 load_dotenv()
 
 API_KEY = os.getenv("ALPACA_API_KEY")
 SECRET_KEY = os.getenv("ALPACA_SECRET_KEY")
 BASE_URL = "https://paper-api.alpaca.markets"
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+
+def send_telegram(message: str) -> None:
+    """Send a Telegram message if credentials are available."""
+    if not TELEGRAM_TOKEN or not TELEGRAM_CHAT_ID:
+        return
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+    try:
+        requests.post(url, data={"chat_id": TELEGRAM_CHAT_ID, "text": message})
+    except Exception as exc:
+        print(f"Failed to send Telegram message: {exc}")
 
 def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
     """Trade any stock and log the decision, price, time, and logic used."""
@@ -30,6 +43,7 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
         return
 
     response = None
+    action = "skipped"
     if price < 500:  # Placeholder logic
         try:
             response = api.submit_order(
@@ -39,11 +53,26 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
                 type="market",
                 time_in_force="gtc",
             )
+            action = "buy"
             print("Buy order placed.")
         except Exception as e:
             print(f"Order failed: {e}")
     else:
         print("Price too high. No order placed.")
+
+    last_price = None
+    if os.path.exists("trade_log.csv"):
+        with open("trade_log.csv") as f:
+            rows = list(csv.reader(f))
+            for row in reversed(rows):
+                if len(row) >= 3 and row[1] == symbol:
+                    try:
+                        last_price = float(row[2])
+                        break
+                    except ValueError:
+                        pass
+
+    profit_loss = price - last_price if last_price is not None else 0.0
 
     # Log everything for future learning
     with open("trade_log.csv", "a", newline="") as f:
@@ -52,9 +81,17 @@ def trade_and_log(symbol: str, strategy_used: str = "test_strategy"):
             datetime.utcnow().isoformat(),
             symbol,
             price,
-            "buy" if response else "skipped",
-            strategy_used
+            action,
+            strategy_used,
+            profit_loss,
         ])
+
+    if response:
+        msg = (
+            f"{symbol} {action} at ${price:.2f}. "
+            f"Strategy: {strategy_used}. P/L: ${profit_loss:.2f}"
+        )
+        send_telegram(msg)
 
 if __name__ == "__main__":
     trade_and_log("AAPL", "price_under_500")


### PR DESCRIPTION
## Summary
- send Telegram alerts when trades execute
- compute simple profit/loss based on prior trade log
- document Telegram environment variables and requests dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490749c1288323a8ca66ead65332fe