### PR TITLE
Add GPT-4 analysis script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,11 @@ This bot will:
 
 1. Install dependencies:
    ```bash
-   pip install alpaca_trade_api python-dotenv pandas
+   pip install alpaca_trade_api python-dotenv pandas openai
+```
+
+2. Set up a `.env` file with your `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`, and `OPENAI_API_KEY`.
+3. After making a trade, run the GPT analyzer:
+   ```bash
+   python gpt_analyzer.py
+   ```

--- a/gpt_analyzer.py
+++ b/gpt_analyzer.py
@@ -1,0 +1,45 @@
+import os
+import pandas as pd
+import openai
+
+
+def analyze_latest_trade():
+    """Use GPT-4 to summarize the most recent trade."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("Missing OpenAI API key.")
+        return
+
+    if not os.path.exists("trade_log.csv"):
+        print("trade_log.csv not found.")
+        return
+
+    openai.api_key = api_key
+
+    df = pd.read_csv(
+        "trade_log.csv",
+        header=None,
+        names=["timestamp", "symbol", "price", "action", "strategy"],
+    )
+    latest = df.iloc[-1].to_dict()
+    prompt = (
+        f"Here is the most recent trade: {latest}. "
+        "Summarize what happened and suggest one improvement."
+    )
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[
+                {"role": "system", "content": "You analyze trading logs."},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        message = response.choices[0].message["content"].strip()
+        print(message)
+    except Exception as e:
+        print(f"OpenAI request failed: {e}")
+
+
+if __name__ == "__main__":
+    analyze_latest_trade()


### PR DESCRIPTION
## Summary
- integrate OpenAI GPT-4 with a new `gpt_analyzer.py` helper
- document OpenAI setup and usage

## Testing
- `python -m py_compile bot.py gpt_analyzer.py`
- `python gpt_analyzer.py` *(fails: Missing OpenAI API key)*
- `python bot.py` *(fails: Missing Alpaca credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68490772968c8323930bb66d033e439a